### PR TITLE
add more messages.

### DIFF
--- a/src/barcodecluster.hpp
+++ b/src/barcodecluster.hpp
@@ -13,7 +13,6 @@
 #include "kmers_dictionary.h"
 #include "typdefine.h"
 
-
 #include <algorithm>
 #include <array>
 #include <list>

--- a/src/clusteroutput.cpp
+++ b/src/clusteroutput.cpp
@@ -28,19 +28,21 @@ ClusterOutput::ClusterOutput(const string& prefix):_filename_prefix(prefix)
     void ClusterOutput::WriteToFile(const std::list<std::shared_ptr<Cluster>>& clusters,
                                     const std::shared_ptr<BarcodePool>& barcode_pool,
                                     size_t max_barcode_length) {
-    if (clusters.empty())
-        return;
-    size_t num_time_points = clusters.front()->columns().size();
-    std::vector<std::unique_ptr<ThreadWrapper>> dumpers;
-        dumpers.push_back(std::unique_ptr<ThreadWrapper>(new ClusterTableDumper(_filename_prefix + "_cluster.csv", num_time_points, clusters)));
-    dumpers.push_back(std::unique_ptr<ThreadWrapper>(new QualityTableDumper(_filename_prefix + "_quality.csv", max_barcode_length, clusters)));
-    dumpers.push_back(std::unique_ptr<ThreadWrapper>(new BarcodeTableDumper(_filename_prefix + "_barcode.csv", clusters, barcode_pool)));
-    for (auto& dumper : dumpers) {
-        dumper->start();
-    }
-    for (auto& dumper : dumpers) {
-        dumper->join();
-    }
+        if (clusters.empty()) {
+            std::cout << "There is no cluster in the result list." << std::endl;
+            return;
+        }
+        size_t num_time_points = clusters.front()->columns().size();
+        std::vector<std::unique_ptr<ThreadWrapper>> dumpers;
+            dumpers.push_back(std::unique_ptr<ThreadWrapper>(new ClusterTableDumper(_filename_prefix + "_cluster.csv", num_time_points, clusters)));
+        dumpers.push_back(std::unique_ptr<ThreadWrapper>(new QualityTableDumper(_filename_prefix + "_quality.csv", max_barcode_length, clusters)));
+        dumpers.push_back(std::unique_ptr<ThreadWrapper>(new BarcodeTableDumper(_filename_prefix + "_barcode.csv", clusters, barcode_pool)));
+        for (auto& dumper : dumpers) {
+            dumper->start();
+        }
+        for (auto& dumper : dumpers) {
+            dumper->join();
+        }
 }
     
 void ClusterOutput::WriteToFile(const std::list<std::shared_ptr<Cluster>>& clusters,size_t max_barcode_length) {


### PR DESCRIPTION
1. Format one function in ClusterOutput class.
2. Print error message when there is no cluster in the result list.