### PR TITLE
Include header files for uint64_6 and size_t

### DIFF
--- a/src/jointentropy.hpp
+++ b/src/jointentropy.hpp
@@ -10,6 +10,7 @@
 #define jointentropy_hpp
 
 #include <array>
+#include <stdint.h>
 namespace barcodeSpace {
     
     /**

--- a/src/mixturebptester.cpp
+++ b/src/mixturebptester.cpp
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <numeric>
+#include <stdint.h>
 namespace barcodeSpace {
 
 MixtureBPTester::MixtureBPTester(double p_value, double error_rate)

--- a/src/mixturebptester.h
+++ b/src/mixturebptester.h
@@ -2,6 +2,8 @@
 #define MIXTUREBPTESTER_H
 
 #include <array>
+#include <cstddef>
+#include <stdint.h>
 namespace barcodeSpace {
 // This class is designed to test if the given frequency array
 // and the position interested

--- a/src/mutualinformationcalculator.hpp
+++ b/src/mutualinformationcalculator.hpp
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <vector>
+#include <stdint.h>
 
 namespace barcodeSpace {
     // This class is designed to calculate the mutual information

--- a/src/split_util.h
+++ b/src/split_util.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <cmath>
 #include <numeric>
+#include <stdint.h>
 
 namespace barcodeSpace {
 


### PR DESCRIPTION
A solution for issue #76.

Hi @LaoZZZZZ and contributors,

I had the same issue # 76, and it seems that `uint64_t` and` size_t` are not defined. Therefore, I added `#include <stdint.h>` and `#include <cstddef>` to source files that use `uint64_t` and` size_t` but are not defined.